### PR TITLE
Make "root" flag configurable via CPPLINT.CFG

### DIFF
--- a/cpplint.py
+++ b/cpplint.py
@@ -201,6 +201,7 @@ Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit]
       filter=+filter1,-filter2,...
       exclude_files=regex
       linelength=80
+      root=subdir
 
     "set noparent" option prevents cpplint from traversing directory tree
     upwards looking for more .cfg files in parent directories. This option
@@ -215,6 +216,9 @@ Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit]
     through the linter.
 
     "linelength" specifies the allowed line length for the project.
+
+    The "root" option is similar in function to the --root flag (see example
+    above).
 
     CPPLINT.cfg has an effect on files in the same directory and all
     subdirectories, unless overridden by a nested configuration file.
@@ -6287,6 +6291,9 @@ def ProcessConfigOverrides(filename):
                 _line_length = int(val)
             except ValueError:
                 _cpplint_state.PrintError('Line length must be numeric.')
+          elif name == 'root':
+            global _root
+            _root = val
           else:
             _cpplint_state.PrintError(
                 'Invalid configuration option (%s) in file %s\n' %


### PR DESCRIPTION
(copied from https://github.com/google/styleguide/pull/129)
