### PR TITLE
Restore optimal travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: python
 # use container infra for linux
 sudo: false
 
+git:
+  depth: 3
+
 python:
   - "3.5"
   - "3.4"
@@ -14,13 +17,17 @@ python:
   - "pypy3"
 
 install:
-  - pip install pyflakes
+  - pip install pyflakes pylint
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 # install: "sudo apt-get install"
 # command to run tests, e.g. python setup.py test
 script:
   - python cpplint_unittest.py
   - python cpplint_clitest.py
-  - pyflakes cpplint.py
-  - pyflakes cpplint_unittest.py
-  - pyflakes cpplint_clitest.py
+  - python cpplint.py --help
+  # code style checker only need to run for latest python
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pyflakes cpplint.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pyflakes cpplint_unittest.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pyflakes cpplint_clitest.py
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pylint --max-locals=25 --max-line-length=100 --max-attributes=10 -d bad-indentation,invalid-name,too-many-statements,multiple-statements,global-statement,missing-docstring,too-many-branches,too-many-return-statements,too-many-arguments,fixme,bad-continuation,bad-option-value,too-few-public-methods,no-self-use,too-many-lines,too-many-function-args,unused-argument,anomalous-unicode-escape-in-string,too-many-boolean-expressions,locally-disabled   cpplint.py; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pylint --max-locals=25 --max-line-length=120 --max-attributes=10 --max-public-methods=200 -d bad-indentation,invalid-name,too-many-statements,multiple-statements,global-statement,missing-docstring,too-many-branches,too-many-return-statements,too-many-arguments,fixme,bad-continuation,bad-option-value,too-few-public-methods,no-self-use,too-many-lines,too-many-function-args,unused-argument,protected-access,unused-variable,global-at-module-level,anomalous-unicode-escape-in-string,locally-disabled  cpplint_unittest.py; fi

--- a/cpplint_unittest.py
+++ b/cpplint_unittest.py
@@ -3024,8 +3024,12 @@ class CpplintTest(CpplintTestBase):
     DoTest(self, ['// hello', 'using namespace foo;'])
 
   def testUsingLiteralsNamespaces(self):
-    self.TestLint('using namespace std::literals;', 'Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces_literals] [5]')
-    self.TestLint('using namespace std::literals::chrono_literals;', 'Do not use namespace using-directives.  Use using-declarations instead.  [build/namespaces_literals] [5]')
+    self.TestLint('using namespace std::literals;',
+                  'Do not use namespace using-directives.  Use using-declarations instead.'
+                  '  [build/namespaces_literals] [5]')
+    self.TestLint('using namespace std::literals::chrono_literals;',
+                  'Do not use namespace using-directives.  Use using-declarations instead.'
+                  '  [build/namespaces_literals] [5]')
 
   def testNewlineAtEOF(self):
     def DoTest(self, data, is_missing_eof):


### PR DESCRIPTION
This is what I originally had in mind.
I only use Python3 for the static checks, because that version of the tools should be most recent.